### PR TITLE
Upgrade Publish and Splash

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -17,8 +17,8 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(url: "https://github.com/johnsundell/publish.git", from: "0.1.0"),
-        .package(url: "https://github.com/johnsundell/splash.git", from: "0.9.0")
+        .package(url: "https://github.com/johnsundell/publish.git", from: "0.5.0"),
+        .package(url: "https://github.com/johnsundell/splash.git", from: "0.11.1")
     ],
     targets: [
         .target(


### PR DESCRIPTION
The current version of Splash will not compile on Xcode 11.4 with Swift 5.2 thus I'd propose to upgrade it together with Splash as well.

Tested using Xcode 11.4 and 11.3, both working fine.