### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ let package = Package(
     ...
     dependencies: [
         ...
-        .package(url: "https://github.com/johnsundell/splashpublishplugin", from: "0.1.0")
+        .package(name: "SplashPublishPlugin", url: "https://github.com/johnsundell/splashpublishplugin", from: "0.1.0")
     ],
     targets: [
         .target(


### PR DESCRIPTION
When I was trying to use SplashPublishPlugin the package needed the name SplashPublishPlugin. Publish was bringing up an error message saying it needed the name.