### PR TITLE
Custom grammars

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,3 +46,19 @@ try DeliciousRecipes().publish(using: [
     ...
 ])
 ```
+
+You can also add your custom Splash Grammars like so:
+
+```swift
+...
+    .installPlugin(.splash(withClassPrefix: "classPrefix", withCustomGrammars: [(YourGrammar(), "name")])
+...
+```
+
+where `name` is the name of the programming language that splash will use to look for in markdown. 
+You could use the grammar above like this:
+
+```markdown
+```name
+...
+```

--- a/Sources/SplashPublishPlugin/SplashPublishPlugin.swift
+++ b/Sources/SplashPublishPlugin/SplashPublishPlugin.swift
@@ -22,13 +22,17 @@ public extension Plugin {
 
 public extension Modifier {
     static func splashCodeBlocks(withFormat format: HTMLOutputFormat = .init()) -> Self {
-        let highlighter = SyntaxHighlighter(format: format)
+        var highlighter = SyntaxHighlighter(format: format)
 
         return Modifier(target: .codeBlocks) { html, markdown in
             var markdown = markdown.dropFirst("```".count)
 
             guard !markdown.hasPrefix("no-highlight") else {
                 return html
+            }
+            
+            if markdown.hasPrefix("yml") || markdown.hasPrefix("yaml") {
+                highlighter = SyntaxHighlighter(format: format, grammar: YamlGrammar())
             }
 
             markdown = markdown

--- a/Sources/SplashPublishPlugin/SplashPublishPlugin.swift
+++ b/Sources/SplashPublishPlugin/SplashPublishPlugin.swift
@@ -9,19 +9,21 @@ import Splash
 import Ink
 
 public extension Plugin {
-    static func splash(withClassPrefix classPrefix: String) -> Self {
+    /// - withClassPrefix: A string to be appended to each HTML tag's class attribute
+    /// - withGrammars: A tuple containing the `Grammar` itself as well as the tag to look for inside of markdown. 
+    static func splash(withClassPrefix classPrefix: String, withGrammars grammars: [(grammar: Grammar, name: String)] = [(SwiftGrammar(), "swift")]) -> Self {
         Plugin(name: "Splash") { context in
             context.markdownParser.addModifier(
                 .splashCodeBlocks(withFormat: HTMLOutputFormat(
                     classPrefix: classPrefix
-                ))
+                ), withGrammars: grammars)
             )
         }
     }
 }
 
 public extension Modifier {
-    static func splashCodeBlocks(withFormat format: HTMLOutputFormat = .init()) -> Self {
+    static func splashCodeBlocks(withFormat format: HTMLOutputFormat = .init(), withGrammars grammars: [(grammar: Grammar, name: String)] = [(SwiftGrammar(), "swift")]) -> Self {
         var highlighter = SyntaxHighlighter(format: format)
 
         return Modifier(target: .codeBlocks) { html, markdown in
@@ -31,9 +33,11 @@ public extension Modifier {
                 return html
             }
             
-            if markdown.hasPrefix("yml") || markdown.hasPrefix("yaml") {
-                highlighter = SyntaxHighlighter(format: format, grammar: YamlGrammar())
-            }
+            grammars.forEach({ grammar, name in
+                if markdown.hasPrefix(name) {
+                    highlighter = SyntaxHighlighter(format: format, grammar: grammar)
+                }
+            })
 
             markdown = markdown
                 .drop(while: { !$0.isNewline })

--- a/Tests/SplashPublishPluginTests/SplashPublishPluginTests.swift
+++ b/Tests/SplashPublishPluginTests/SplashPublishPluginTests.swift
@@ -7,6 +7,7 @@
 import XCTest
 import SplashPublishPlugin
 import Ink
+import Splash
 
 final class SplashPublishPluginTests: XCTestCase {
     func testHighlightingMarkdown() {
@@ -28,8 +29,78 @@ final class SplashPublishPluginTests: XCTestCase {
         </code></pre>
         """)
     }
+    
+    func testHighlightingMultipleGrammarsMarkdown() {
+        let parser = MarkdownParser(modifiers: [.splashCodeBlocks(withGrammars: [(TestGrammar(), "test"), (SwiftGrammar(), "swift")])])
+        let html = parser.html(from: """
+        Some text
+        ```test
+        some should be a keyword
+        ```
+        here's some fake text
+        ```swift
+        let int = 7
+        ```
+        fake text
+        ```no-highlight
+        not.highlighted()
+        ```
+        """)
+        XCTAssertEqual(html, """
+        <p>Some text</p><pre><code><span class=\"keyword\">some</span> should be a keyword\n</code></pre><p>here\'s some fake text</p><pre><code><span class=\"keyword\">let</span> int = <span class=\"number\">7</span>\n</code></pre><p>fake text</p><pre><code class=\"language-no-highlight\">not.highlighted()\n</code></pre>
+        """)
+    }
 
     static var allTests = [
         ("testHighlightingMarkdown", testHighlightingMarkdown)
     ]
+}
+
+public struct TestGrammar: Grammar {
+    public var delimiters: CharacterSet
+    public var syntaxRules: [SyntaxRule]
+    
+    public init() {
+        var delimiters = CharacterSet.alphanumerics.inverted
+        delimiters.remove("_")
+        delimiters.remove("-")
+        delimiters.remove("\"")
+        delimiters.remove("#")
+        delimiters.remove("@")
+        delimiters.remove("$")
+        self.delimiters = delimiters
+        
+        syntaxRules = [
+            KeywordRule(),
+        ]
+    }
+    
+    public func isDelimiter(_ delimiterA: Character, mergableWith delimiterB: Character) -> Bool {
+        switch (delimiterA, delimiterB) {
+        case (_, ":"):
+            return false
+        case (":", "/"):
+            return true
+        case (":", _):
+            return false
+        case ("-", _):
+            return false
+        case ("#", _):
+            return false
+        default:
+            return true
+        }
+    }
+    
+    static let keywords = ([
+        "some", "fake", "keywords"
+    ] as Set<String>)
+    
+    struct KeywordRule: SyntaxRule {
+        var tokenType: TokenType { return .keyword }
+        
+        func matches(_ segment: Segment) -> Bool {
+            return keywords.contains(segment.tokens.current)
+        }
+    }
 }


### PR DESCRIPTION
This PR adds an argument to `.installPlugin` that takes a set of custom `Grammar`s to use while highlighting code in markdown.

Let's say we've created a custom `Grammar` called `YamlGrammar`. We can use it with this PR like so:

```
.installPlugin(.splash(withClassPrefix: "", withGrammars: [(YamlGrammar(), "yaml"), (SwiftGrammar(), "swift")])
```

This will apply the grammar to any code blocks in markdown prepended with "yaml", like so:

```
```yaml
...
```

I wrote a unit test but I did struggle getting Xcode to recognize the string to compare with. I had to escape some quotes and add newlines to get it working even though I noticed this wasn't done in the first unit test. Hope that's okay!

I also took the liberty of adding brief instructions to the README. Hopefully it reads well 😂